### PR TITLE
fix redirectLocation action

### DIFF
--- a/src/fetch/loadClientState.js
+++ b/src/fetch/loadClientState.js
@@ -54,6 +54,7 @@ const registerHook = ({ history, routes, store, getLocals, location, beforeResol
 
     match({ location, routes }, (error, redirectLocation, renderProps) => {
       if (redirectLocation) {
+        redirectLocation.action = "PUSH";
         history.transitionTo(redirectLocation);
       } else if (renderProps) {
         const { components } = renderProps;

--- a/src/fetch/loadClientState.js
+++ b/src/fetch/loadClientState.js
@@ -54,7 +54,7 @@ const registerHook = ({ history, routes, store, getLocals, location, beforeResol
 
     match({ location, routes }, (error, redirectLocation, renderProps) => {
       if (redirectLocation) {
-        redirectLocation.action = "PUSH";
+        continueTransition();
         history.transitionTo(redirectLocation);
       } else if (renderProps) {
         const { components } = renderProps;


### PR DESCRIPTION
When a redirectLocation is given, we need to make sure, it creates a new item on the history stack.
In the current implementation the ongoing transition, which is supposed to create the stack item, is stopped and the top item is replaced with the new location. This causes links not to occur in the history, if they trigger redirects.

There are two ways to fix this:

1) execute continueTransition() before the redirect (Pushing the original location onto the stack and replacing it afterwards)
2) cancel the ongoing transition and replace the action of the redirectLocation with "PUSH"

The second solution should probably be a bit faster.
