### PR TITLE
redirects should not overwrite the last history entry

### DIFF
--- a/example/src/components/App.js
+++ b/example/src/components/App.js
@@ -43,6 +43,12 @@ export default class App extends Component {
           <Link to="/counter">Go to Counter</Link>
         </div>
         <div>
+          <Link to="/counter-test">Go to Counter-Query via redirect</Link>
+        </div>
+        <div>
+          <Link to="/counter-query">Go to Counter-Query with onEnter hook to add query parameters</Link>
+        </div>
+        <div>
           <Link to="/async">Go to Async</Link>
         </div>
         <div>

--- a/example/src/routes/createRoutes.js
+++ b/example/src/routes/createRoutes.js
@@ -1,13 +1,30 @@
 require('require-ensure-shim').shim(require);
 
 import React from 'react';
-import { Route } from 'react-router';
+import { Route, Redirect } from 'react-router';
 import App from '../components/App';
 import Counter from '../components/counter/Counter';
+
+function onEnter(nextState, replaceState) {
+  const { location } = nextState;
+
+  if (!location.query.sort) {
+    const newLocation = {
+      pathname: location.pathname,
+      state: location.state,
+      query: {
+        sort: 'asc',
+      },
+    };
+    replaceState(newLocation);
+  }
+}
 
 export default function createRoutes() {
   return (
     <Route path="/" component={App}>
+      <Redirect from="counter-test" to="counter-query"/>
+      <Route path="counter-query" component={Counter} onEnter={onEnter}/>
       <Route path="counter" component={Counter}/>
       <Route path="async" getComponent={function getComponent(location, cb) {
         require.ensure([], (require) => {

--- a/src/fetch/loadClientState.js
+++ b/src/fetch/loadClientState.js
@@ -54,6 +54,7 @@ const registerHook = ({ history, routes, store, getLocals, location, beforeResol
 
     match({ location, routes }, (error, redirectLocation, renderProps) => {
       if (redirectLocation) {
+        redirectLocation.action = 'PUSH';
         history.transitionTo(redirectLocation);
       } else if (renderProps) {
         const { components } = renderProps;


### PR DESCRIPTION
fixes issue in #1 with the "PUSH" hack and add some examples

run example
```
npm run build:dev
cd example
npm start
```

go to http://localhost:3000/

